### PR TITLE
[ros_sam] Install segment anything

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ __pycache__/
 *$py.class
 
 # Ignore downloaded models
-models/*
-!models/.gitkeep
+ros_sam/models/*
+ros_sam/!models/.gitkeep

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This package is what the name suggests: Meta's `segment-anything` wrapped in a R
 Installation is easy: 
  1. Start by cloning this package into your ROS environment. 
  2. Download the [checkpoints](https://github.com/facebookresearch/segment-anything#model-checkpoints) for the desired SAM models to the `models` directory in this package.
- 3. Install SAM by running `pip install git+https://github.com/facebookresearch/segment-anything.git`.
 
 
 ## Using ROS SAM standalone

--- a/ros_sam/CMakeLists.txt
+++ b/ros_sam/CMakeLists.txt
@@ -4,156 +4,37 @@ project(ros_sam)
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   rospy
   cv_bridge
   ros_sam_msgs
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -m pip install --upgrade pip
+)
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} -m pip install git+https://github.com/facebookresearch/segment-anything.git
+)
+
+## Use this if the package has a setup.py. This macro ensures
 catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Segmentation.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   geometry_msgs
-#   sensor_msgs
-#   std_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES ros_sam
-#  CATKIN_DEPENDS geometry_msgs rospy sensor_msgs std_msgs
-#  DEPENDS system_lib
+  CATKIN_DEPENDS rospy cv_bridge ros_sam_msgs
 )
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-# include
-  ${catkin_INCLUDE_DIRS}
-)
-
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/ros_sam.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/ros_sam_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
 
 #############
 ## Install ##
 #############
+catkin_install_python(PROGRAMS
+  scripts/sam_node.py
+  scripts/sam_test.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 # all install targets should use catkin DESTINATION variables
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html

--- a/ros_sam/package.xml
+++ b/ros_sam/package.xml
@@ -3,64 +3,25 @@
   <name>ros_sam</name>
   <version>0.0.0</version>
   <description>The ros_sam package</description>
-
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="aroefer@cs.uni-freiburg.de">Adrian Röfer</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>GPLv3</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/ros_sam</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-    <build_depend>message_generation</build_depend>
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-    <build_export_depend>message_generation</build_export_depend>
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-    <exec_depend>message_runtime</exec_depend>
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
+  <build_depend>message_generation</build_depend>
+  <build_export_depend>message_generation</build_export_depend>
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>ros_sam_msgs</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>ros_sam_msgs</build_export_depend>
+  <exec_depend>message_runtime</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>ros_sam_msgs</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
-  <!-- The export tag contains other, unspecified, tags -->
+  
   <export>
-    <!-- Other tools can request additional information be placed here -->
 
   </export>
 </package>

--- a/ros_sam/requirements.txt
+++ b/ros_sam/requirements.txt
@@ -1,3 +1,6 @@
 matplotlib
 numpy
 opencv-python
+torch
+torchvision
+pyyaml

--- a/ros_sam/setup.py
+++ b/ros_sam/setup.py
@@ -1,21 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-# Try catkin install
-from catkin_pkg.python_setup import generate_distutils_setup
-from distutils.core import setup
-
+from setuptools import setup, find_packages
 from pathlib import Path
 
+with open(Path(__file__).parent / "requirements.txt") as f:
+    pip_dependencies = [line.strip() for line in f if line.strip()]
 
-with open(f'{Path(__file__).parent}/requirements.txt', 'r') as f:
-   pip_dependencies = f.readlines()
-
-
-d = generate_distutils_setup(
-   packages=['ros_sam'],
-   package_dir={'': 'src'}
+setup(
+    name='ros_sam',
+    version='0.0.0',
+    packages=find_packages(where='src'),
+    package_dir={'': 'src'},
+    install_requires=pip_dependencies,
 )
-
-d.update({'install_requires': pip_dependencies})
-
-setup(**d)


### PR DESCRIPTION
## Main update
Currently, as described in README.md,
 We should install SAM by running `pip install git+https://github.com/facebookresearch/segment-anything.git`. I think the reason for this might be that `install git+https://github.com/facebookresearch/segment-anything.git` is not available in setup.py.

I fix CMakelists.txt to install segement_anything when catkin build ros_sam by running commands below.
```
execute_process(
  COMMAND ${Python3_EXECUTABLE} -m pip install git+https://github.com/facebookresearch/segment-anything.git
```
I 

## Also,
1. This PR fixes path of model in .gitignore.
2. This PR fixes setup.py (replace distutils with setuptools).
3. This PR fixes package dependencies.